### PR TITLE
Set resizable to false again

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -36,7 +36,7 @@ function createWindow() {
     'show': false,
     'transparent': true,
     'maximizable': false,
-    'resizable': true,
+    'resizable': false,
     'fullscreenable': false,
     'alwaysOnTop': true
   });

--- a/src/main.js
+++ b/src/main.js
@@ -148,7 +148,7 @@ ipcMain.on("resize", function (ev, width, height) {
   let windowPosition = win.getPosition();
 
   // Set new window size
-  win.setSize(Math.round(width), Math.round(height));
+  win.setContentSize(Math.round(width), Math.round(height));
 
   // Apply previous position again to fix up- and downwards resize on some Linux distros
   if(os.platform() === "linux") {


### PR DESCRIPTION
It already is resizable by using the scale factor, and it messes
up my i3wm system because then it automatically changes the
size to fit with the other windows. It also doesn't actually resize.
I assume this is the reason it was put there in the first place.

I'm guessing this was put here to scale to a full
monitor, which should be further looked at.