### PR TITLE
Remove Seed API call

### DIFF
--- a/src/modules/poe-ninja.js
+++ b/src/modules/poe-ninja.js
@@ -27,7 +27,6 @@ class NinjaAPI {
         this.apis = [
             { overview: "currency", type: "Currency" },
             { overview: "currency", type: "Fragment" },
-            { overview: "item", type: "Seed" },
             { overview: "item", type: "DeliriumOrb" },
             { overview: "item", type: "Watchstone" },
             { overview: "item", type: "Oil" },


### PR DESCRIPTION
This fixes #12 - PoE.ninja isn't tracking seed prices any more as we are no longer in Harvest. It doesn't look as if they're even tracking them in Standard, hence the total removal of the call.